### PR TITLE
Clarify that roles are not deleted

### DIFF
--- a/docs/attendee_roles.md
+++ b/docs/attendee_roles.md
@@ -9,8 +9,8 @@ There are two options for assigning a role to attendees:
 - Use an [existing role](#persistent-attendee-roles) on your server
 
 Once an attendee role is setup, attendees will be given the role when they sign
-up for the event. The role will be removed when a user removes their sign up, or
-the event is deleted.
+up for the event. The role will be removed from attendees when they remove their
+signup, or the event is deleted.
 
 !!! warning
     Apollo must have the `Manage Roles` permission in order to assign roles to


### PR DESCRIPTION
While temporary roles are removed after the event, persistent roles
aren't. As this is the general overview section of the guide, I don't want
there to be any confusion that roles are always removed.