### PR TITLE
Add documentation for threads & buttons

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -25,6 +25,7 @@ Information on how to use a command can also be found via the `!help` command.
 | `!server localize_time`     | Configure if users see event times in their local time zone |
 | `!server purge`             | Configure if messages are purged from event channels |
 | `!server reminder_interval <interval>` | Configure when event reminders are delivered |
+| `!server event_threads`     | Configure if events are posted with a thread |
 | `!server role event`        | Configure which role is allowed to create events |
 | `!server role delete`       | Configure which role is allowed to delete events |
 | `!server role channel`      | Configure which role is allowed to create event channels |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -26,6 +26,7 @@ Information on how to use a command can also be found via the `!help` command.
 | `!server purge`             | Configure if messages are purged from event channels |
 | `!server reminder_interval <interval>` | Configure when event reminders are delivered |
 | `!server event_threads`     | Configure if events are posted with a thread |
+| `!server thread_reminders`  | [Configure if event reminders are sent in a thread](./reminders.md#channel-reminders) |
 | `!server role event`        | Configure which role is allowed to create events |
 | `!server role delete`       | Configure which role is allowed to delete events |
 | `!server role channel`      | Configure which role is allowed to create event channels |

--- a/docs/deleting_events.md
+++ b/docs/deleting_events.md
@@ -3,17 +3,17 @@
 Events can be deleted in two ways
 
 - By deleting the event message (requires the `Manage Messages` permission)
-- By clicking the :wastebasket: emoji on the event message
+- By clicking the `Delete` button on the event message
 
-Deleting the event message will instantly delete the event. If the :wastebasket:
-emoji is clicked, a confirmation prompt will be sent via a direct message.
+Deleting the event message will instantly delete the event. If the `Edit`
+button is clicked, a confirmation prompt will be sent via a direct message.
 
 ## Recurring events
 
 If an event message for a recurring event is deleted, the underlying series is
 not deleted.
 
-When the :wastebasket: emoji is selected for a recurring event, a prompt will
+When the `Delete` button is selected for a recurring event, a prompt will
 ask if you'd like to delete the current event only, or if you'd like to delete
 the current event and prevent all future occurrences.
 
@@ -29,7 +29,7 @@ series.
 ## Controlling access
 
 By default, users can only delete their own events. If a user clicks on the
-:wastebasket: emoji for an event they don't own, they will receive a direct
+`Delete` button for an event they don't own, they will receive a direct
 message indicating that they are missing permissions.
 
 Users with the `Manage Server` permission can delete any event.

--- a/docs/deleting_events.md
+++ b/docs/deleting_events.md
@@ -8,6 +8,10 @@ Events can be deleted in two ways
 Deleting the event message will instantly delete the event. If the `Edit`
 button is clicked, a confirmation prompt will be sent via a direct message.
 
+!!! note
+    When an event is deleted that Apollo has created a thread for, the thread
+    is automatically archived.
+
 ## Recurring events
 
 If an event message for a recurring event is deleted, the underlying series is

--- a/docs/event_channels.md
+++ b/docs/event_channels.md
@@ -58,6 +58,7 @@ channel. This limit is increased to **25** if there is an active Premium members
 ## Purge non event messages
 
 By default non event messages (that aren't pinned) are purged from an event
-channel when a new event is posted in the channel.
+channel when a new event is posted or deleted. The goal of this feature is to
+maintain an event channel as a place for events only, free of distraction.
 
 This can be disabled with the `!server purge off` command.

--- a/docs/event_channels.md
+++ b/docs/event_channels.md
@@ -62,3 +62,7 @@ channel when a new event is posted or deleted. The goal of this feature is to
 maintain an event channel as a place for events only, free of distraction.
 
 This can be disabled with the `!server purge off` command.
+
+!!! note
+    When a message with a thread (that isn't an event message) is deleted as
+    part of a purge, the thread remains intact.

--- a/docs/modifying_events.md
+++ b/docs/modifying_events.md
@@ -6,7 +6,7 @@ creating an event or the event details have changed.
 Events can be modified in two ways:
 
 - With the `!edit` command
-- By clicking the :pencil: emoji on an event
+- By clicking the `Edit` button on an event
 
 !!! info
     To modify a recurring series without affecting an already posted event, the

--- a/docs/reminders.md
+++ b/docs/reminders.md
@@ -1,0 +1,31 @@
+# Reminders
+
+By default, Apollo will send a reminder to event attendees **15** minutes prior to
+the scheduled start time of the event.
+
+!!! info
+    The timing of reminders can be modified with the `!server reminder_interval`
+    command, which applies to all events on the server.
+
+When it's time to send a reminder, Apollo will create a public thread on the
+event and send a reminder in the thread that mentions relevent attendees. If a
+thread already exists for the event, Apollo will send a reminder in the existing
+thread.
+
+## Configuring reminders
+
+Reminders are sent when:
+
+- The user has reminders enabled
+- The user is signed up for an option that has reminders enabled
+
+Users are opted in to reminders by default, but they can opt out with
+`!reminders off`.
+
+By default, only the **Accepted** signup option has reminders enabled, but this
+can be configured during event creation or when editing an event.
+
+## Channel reminders
+
+By default reminders are sent in a thread, but they optionally be sent in the
+event channel instead via the `!server thread_reminders` command.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,4 +42,5 @@ nav:
     - Deleting events: 'deleting_events.md'
     - Modifying events: 'modifying_events.md'
     - Event channels: 'event_channels.md'
+    - Reminders: 'reminders.md'
     - Attendee roles: 'attendee_roles.md'


### PR DESCRIPTION
With the upcoming changes to Apollo around threads and buttons, our documentation will need to be updated!

### Todo

- [x] purge on delete
- [x] deleting events
- [x] editing events
- [x] event reminders
- [x] event threads command
- [x] thread reminders command